### PR TITLE
Feature/advanced discourse analysis

### DIFF
--- a/app/dynamicQuestionAnswering/dynamicQuestionAnswerer.js
+++ b/app/dynamicQuestionAnswering/dynamicQuestionAnswerer.js
@@ -98,14 +98,15 @@ exports.answer = function(question, callback, fallback) {
                 id: id,
                 label: queryResult.objectLabel.value
             };
-            console.log(answerEntity);
+
             if (queryResult.genderLabel) {
                 answerEntity.gender = queryResult.genderLabel.value;
             } else if (id) {
                 answerEntity.gender = 'neutr';
-            } {
+            } else {
                 answerEntity.gender = null;
             }
+            console.log(answerEntity);
             data.result = answerEntity;
             conversationHistory.addAnswerEntity(answerEntity, questionId);
 

--- a/app/dynamicQuestionAnswering/dynamicQuestionAnswerer.js
+++ b/app/dynamicQuestionAnswering/dynamicQuestionAnswerer.js
@@ -67,9 +67,12 @@ exports.answer = function(question, callback, fallback) {
         });
 
         function onQueryResult(queryData) {
-            var data = {};
+            var data = {
+                property: property,
+                namedEntity: namedEntity,
+                interpretation: property.label + " of " + namedEntity.label + "?"
+            };
 
-            data.interpretation = property.label + " of " + namedEntity.label + "?";
             conversationHistory.addInterpretation(data.interpretation, questionId);
 
             var jsonResponse = JSON.parse(decoder.write(queryData));
@@ -83,7 +86,6 @@ exports.answer = function(question, callback, fallback) {
 
             var queryResult = jsonResponse.results.bindings[0];
 
-            data.result = queryResult.objectLabel.value;
             data.answer = answerFormatter.formatAnswer(property, namedEntity, queryResult);
             conversationHistory.addAnswer(data.answer, questionId);
             var answerIdPart = queryResult.object.value;
@@ -91,7 +93,11 @@ exports.answer = function(question, callback, fallback) {
                 id: answerIdPart.substring(answerIdPart.lastIndexOf('Q'), answerIdPart.length),
                 label: queryResult.objectLabel.value
             };
+
+            data.result = answerEntity;
             conversationHistory.addAnswerEntity(answerEntity, questionId);
+
+            console.log(data);
             callback(data);
         }
     }

--- a/app/dynamicQuestionAnswering/dynamicQuestionAnswerer.js
+++ b/app/dynamicQuestionAnswering/dynamicQuestionAnswerer.js
@@ -37,10 +37,6 @@ exports.answer = function(question, callback, fallback) {
     }
 
     function onEntityDetected(taggedWords, position) {
-        console.log("Tagged words: " + taggedWords);
-        console.log("QuestionID: " + questionId);
-        console.log("Position: " + position);
-        console.log("onPropertyFound: " + onPropertyFound);
         propertyResolver.findPropertyId(taggedWords, questionId, position, onPropertyFound);
     }
 
@@ -77,6 +73,7 @@ exports.answer = function(question, callback, fallback) {
             var data = {
                 property: property,
                 namedEntity: namedEntity,
+                result: {},
                 interpretation: property.label + " of " + namedEntity.label + "?"
             };
 
@@ -96,12 +93,18 @@ exports.answer = function(question, callback, fallback) {
             data.answer = answerFormatter.formatAnswer(property, namedEntity, queryResult);
             conversationHistory.addAnswer(data.answer, questionId);
             var answerIdPart = queryResult.object.value;
+            var id = answerIdPart.lastIndexOf('Q') !== -1 ? answerIdPart.substring(answerIdPart.lastIndexOf('Q'), answerIdPart.length) : null;
             var answerEntity = {
-                id: answerIdPart.substring(answerIdPart.lastIndexOf('Q'), answerIdPart.length),
+                id: id,
                 label: queryResult.objectLabel.value
             };
+            console.log(answerEntity);
             if (queryResult.genderLabel) {
                 answerEntity.gender = queryResult.genderLabel.value;
+            } else if (id) {
+                answerEntity.gender = 'neutr';
+            } {
+                answerEntity.gender = null;
             }
             data.result = answerEntity;
             conversationHistory.addAnswerEntity(answerEntity, questionId);

--- a/app/dynamicQuestionAnswering/dynamicQuestionAnswerer.js
+++ b/app/dynamicQuestionAnswering/dynamicQuestionAnswerer.js
@@ -23,8 +23,7 @@ exports.answer = function(question, callback, fallback) {
     var questionNormalized = normalizeInterpunctuation(question);
 
     spacyClient.getSpacyTaggedWords(questionNormalized, function(spacyTaggedWords) {
-        entityResolver.findNamedEntity(spacyTaggedWords, questionId, onEntityFound);
-        propertyResolver.findPropertyId(spacyTaggedWords, questionId, onPropertyFound);
+        entityResolver.findNamedEntity(spacyTaggedWords, questionId, onEntityDetected, onEntityFound);
     });
 
     function onEntityFound(err, foundEntity) {
@@ -35,6 +34,14 @@ exports.answer = function(question, callback, fallback) {
         if (bothResultsArrived()) {
             buildQuery();
         }
+    }
+
+    function onEntityDetected(taggedWords, position) {
+        console.log("Tagged words: " + taggedWords);
+        console.log("QuestionID: " + questionId);
+        console.log("Position: " + position);
+        console.log("onPropertyFound: " + onPropertyFound);
+        propertyResolver.findPropertyId(taggedWords, questionId, position, onPropertyFound);
     }
 
     function onPropertyFound(err, foundProperty) {
@@ -93,7 +100,9 @@ exports.answer = function(question, callback, fallback) {
                 id: answerIdPart.substring(answerIdPart.lastIndexOf('Q'), answerIdPart.length),
                 label: queryResult.objectLabel.value
             };
-
+            if (queryResult.genderLabel) {
+                answerEntity.gender = queryResult.genderLabel.value;
+            }
             data.result = answerEntity;
             conversationHistory.addAnswerEntity(answerEntity, questionId);
 

--- a/app/dynamicQuestionAnswering/entityResolver.js
+++ b/app/dynamicQuestionAnswering/entityResolver.js
@@ -69,7 +69,7 @@ function extractNamedEntity(taggedWords, namedEntityDetected) {
     if (type === "PERSON") {
         gender = "?";
     } else {
-        gender = null;
+        gender = 'neuter';
     }
     return {
         string: namedEntityString.trim(),

--- a/app/dynamicQuestionAnswering/entityResolver.js
+++ b/app/dynamicQuestionAnswering/entityResolver.js
@@ -4,42 +4,90 @@ var wikidataIdLookup = require('./../wikidataIdLookup');
 var conversationHistory = require('./../conversationHistory.js');
 
 
-exports.findNamedEntity = function(taggedWords, questionId, callback) {
-    var namedEntityString = extractNamedEntityString(taggedWords);
+exports.findNamedEntity = function(taggedWords, questionId, namedEntityDetected, entityFound) {
+    var namedEntityString = extractNamedEntityString(taggedWords, namedEntityDetected);
 
     if (namedEntityString === "") {
-        returnHistoryEntityInstead(callback, questionId);
+        returnHistoryEntityInstead(entityFound, namedEntityDetected, questionId, taggedWords);
         return;
     }
     console.log("Extracted Named Entity:", namedEntityString.trim());
 
     wikidataIdLookup.getWikidataId({searchText: namedEntityString.trim()}, function(err, data) {
         if (err) {
-            returnHistoryEntityInstead(callback, questionId);
+            returnHistoryEntityInstead(entityFound, questionId, namedEntityDetected, taggedWords);
             return;
         }
-        callback(null, {id: data.id, label: data.label});
+        entityFound(null, {id: data.id, label: data.label});
     });
 };
 
 
-function returnHistoryEntityInstead(callback, questionId) {
+function returnHistoryEntityInstead(entityFound, namedEntityDetected, questionId, taggedWords) {
     if (conversationHistory.wasEmpty()) {
-        callback("Could not find named entity in question or conversation history.");
+        entityFound("Could not find named entity in question or conversation history.");
         return;
     }
-    var namedEntity = conversationHistory.messages()[questionId - 1].answerEntity;
-    console.log("Didn't find namedEntity in question; using instead: ", namedEntity);
-    callback(null, namedEntity);
+
+    var gender = detectGender(taggedWords, namedEntityDetected);
+
+    for (var i = questionId - 1; i > questionId - 4 && i >= 0; i--) {
+        var answerEntity = conversationHistory.messages()[i].answerEntity;
+        var namedEntity = conversationHistory.messages()[i].namedEntity;
+        if (gender == answerEntity.gender) {
+            console.log("Didn't find namedEntity in question; using instead: ", answerEntity);
+            entityFound(null, answerEntity);
+            return;
+        }
+        if (gender == namedEntity.gender) {
+            console.log("Didn't find namedEntity in question; using instead: ", namedEntity);
+            entityFound(null, namedEntity);
+            return;
+        }
+    }
+
+    console.log("Didn't find namedEntity in question; using instead: ", conversationHistory.messages()[questionId - 1].answerEntity);
+    entityFound(null, conversationHistory.messages()[questionId - 1].answerEntity);
+
 }
 
-function extractNamedEntityString(taggedWords) {
-    console.log(taggedWords);
+function extractNamedEntityString(taggedWords, namedEntityDetected) {
+    var found = false;
     var namedEntityString = "";
     for (var i = 0; i < taggedWords.length; i++) {
         if (taggedWords[i].entType !== '') {
             namedEntityString += taggedWords[i].orth + " ";
+            if (!found) {
+                namedEntityDetected(taggedWords, i);
+            }
         }
     }
     return namedEntityString.trim();
+}
+
+function detectGender(taggedWords, namedEntityDetected) {
+    console.log("no named entity found, looking instead for words like 'he', 'she', 'it', ...");
+    for (var i = 0; i < taggedWords.length; i++) {
+        console.log(taggedWords[i].orth);
+        switch (taggedWords[i].orth) {
+            case 'he':
+            case 'him':
+            case 'his':
+                namedEntityDetected(taggedWords, i);
+                console.log(i);
+                return 'male';
+            case 'she':
+            case 'her':
+                namedEntityDetected(taggedWords, i);
+                console.log(i);
+                return 'female';
+            case 'it':
+            case 'its':
+                namedEntityDetected(taggedWords, i);
+                console.log(i);
+                return undefined;
+            default:
+                break;
+        }
+    }
 }

--- a/app/dynamicQuestionAnswering/propertyResolver.js
+++ b/app/dynamicQuestionAnswering/propertyResolver.js
@@ -35,7 +35,7 @@ function findProperty(taggedWords, positions) {
     propertyPartsArray = [];
     var rootIndex = findRootIndex(taggedWords);
     // assuming, only one children-path yields to namedEntity
-    if (findPropertyString(taggedWords, rootIndex, positions)) {
+    if (findPropertyString(taggedWords, rootIndex, 0, positions)) {
         var result = propertyPartsArray[propertyPartsArray.length-1] === "of" ? propertyPartsArray.slice(0, propertyPartsArray.length - 1).join(' ') : propertyPartsArray.join(' ');
         return result;
     } else {
@@ -137,24 +137,30 @@ function isFirstWordIn(description, context) {
 }
 
 
-function findPropertyString(taggedWords, index, positionsOfNamedEntity) {
+function findPropertyString(taggedWords, index, amountOfVerbsOrNouns, positionsOfNamedEntity) {
     var element = taggedWords[index];
-    if (positionsOfNamedEntity.indexOf(index) !== -1) {
+    if (positionsOfNamedEntity.indexOf(index) !== -1 && amountOfVerbsOrNouns > 0) {
         return true;
     }
 
     if (element.lemma !== "be" && element.lemma !== "have") {
         propertyPartsArray.push(element.orth);
+        if (element.tag.startsWith('V') || element.tag.startsWith('NN')) {
+            amountOfVerbsOrNouns++;
+        }
     }
 
     for (var i = 0; i < element.depChildren.length; i++) {
-        if (findPropertyString(taggedWords, element.depChildren[i].pos, positionsOfNamedEntity)) {
+        if (findPropertyString(taggedWords, element.depChildren[i].pos, amountOfVerbsOrNouns, positionsOfNamedEntity)) {
             return true;
         }
     }
 
     if (element.lemma !== "be" && element.lemma !== "have") {
         propertyPartsArray = propertyPartsArray.slice(0, propertyPartsArray.length - 1);
+        if (element.tag.startsWith('V') || element.tag.startsWith('NN')) {
+            amountOfVerbsOrNouns--;
+        }
     }
     return false;
 }

--- a/app/sparqlConstants.js
+++ b/app/sparqlConstants.js
@@ -2,8 +2,9 @@
 
 var querystring = require("querystring");
 
-var GENERIC_SINGLE_STATEMENT = "SELECT ?object ?objectLabel WHERE { " +
+var GENERIC_SINGLE_STATEMENT = "SELECT ?object ?objectLabel ?gender ?genderLabel WHERE { " +
             "  wd:[ITEM_ID] wdt:[PROPERTY_ID] ?object . " +
+            "  OPTIONAL {?object  wdt:P21 ?gender . } " +
             "  SERVICE wikibase:label { bd:serviceParam wikibase:language 'en' . } " +
             "}";
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "private": true,
   "scripts": {
-    "start": "concurrently \"node app.js\" \"python spacyServer/spacyServer.py\""
+    "start": "concurrently \"nodemon app.js\" \"python spacyServer/spacyServer.py\""
   },
   "dependencies": {
     "async": "^1.5.2",

--- a/test/basicQuestions.js
+++ b/test/basicQuestions.js
@@ -10,7 +10,7 @@ describe('basicQuestions', function() {
 
         app.answer('Where was Angela Merkel born?', function(answer) {
             assert.equal(answer.interpretation, 'place of birth of Angela Merkel?');
-            assert.equal(answer.result, 'Barmbek-Nord');
+            assert.equal(answer.result.label, 'Barmbek-Nord');
             done();
         });
     });
@@ -19,7 +19,7 @@ describe('basicQuestions', function() {
 
         app.answer('Where was Merkel born?', function(answer) {
             assert.equal(answer.interpretation, 'place of birth of Angela Merkel?');
-            assert.equal(answer.result, 'Barmbek-Nord');
+            assert.equal(answer.result.label, 'Barmbek-Nord');
             done();
         });
     });
@@ -28,7 +28,7 @@ describe('basicQuestions', function() {
 
         app.answer('When was Angela Merkel born?', function(answer) {
             assert.equal(answer.interpretation, 'date of birth of Angela Merkel?');
-            assert.equal(answer.result, '1954-07-17T00:00:00Z');
+            assert.equal(answer.result.label, '1954-07-17T00:00:00Z');
             done();
         });
     });
@@ -37,7 +37,7 @@ describe('basicQuestions', function() {
 
         app.answer('When died Albert Einstein?', function(answer) {
             assert.equal(answer.interpretation, 'date of death of Albert Einstein?');
-            assert.equal(answer.result, '1955-04-18T00:00:00Z');
+            assert.equal(answer.result.label, '1955-04-18T00:00:00Z');
             done();
         });
     });
@@ -46,7 +46,7 @@ describe('basicQuestions', function() {
 
         app.answer('When did Albert Einstein die?', function(answer) {
             assert.equal(answer.interpretation, 'date of death of Albert Einstein?');
-            assert.equal(answer.result, '1955-04-18T00:00:00Z');
+            assert.equal(answer.result.label, '1955-04-18T00:00:00Z');
             done();
         });
     });
@@ -55,7 +55,7 @@ describe('basicQuestions', function() {
 
         app.answer('Where died Albert Einstein?', function(answer) {
             assert.equal(answer.interpretation, 'place of death of Albert Einstein?');
-            assert.equal(answer.result, 'Princeton');
+            assert.equal(answer.result.label, 'Princeton');
             done();
         });
     });
@@ -65,7 +65,7 @@ describe('basicQuestions', function() {
 
         app.answer('Who founded Siemens?', function(answer) {
             assert.equal(answer.interpretation, 'founder of Siemens?');
-            assert.equal(answer.result, 'Ernst Werner von Siemens');
+            assert.equal(answer.result.label, 'Ernst Werner von Siemens');
             done();
         });
     });
@@ -74,7 +74,7 @@ describe('basicQuestions', function() {
 
         app.answer('What is the population of Germany? ', function(answer) {
             assert.equal(answer.interpretation, 'population of Germany?');
-            assert.equal(answer.result, '81292400');
+            assert.equal(answer.result.label, '81292400');
             done();
         });
     });
@@ -83,7 +83,7 @@ describe('basicQuestions', function() {
 
         app.answer('What is Germany\'s population? ', function(answer) {
             assert.equal(answer.interpretation, 'population of Germany?');
-            assert(answer.result > '75000000');
+            assert(answer.result.label > '75000000');
             done();
         });
     });
@@ -93,7 +93,7 @@ describe('basicQuestions', function() {
 
         app.answer('Who is the president of Germany? ', function(answer) {
             assert.equal(answer.interpretation, 'head of state of Germany?');
-            assert.equal(answer.result, 'Joachim Gauck');
+            assert.equal(answer.result.label, 'Joachim Gauck');
             done();
         });
     });
@@ -102,7 +102,7 @@ describe('basicQuestions', function() {
 
         app.answer('Who is the head of government of Germany? ', function(answer) {
             assert.equal(answer.interpretation, 'head of government of Germany?');
-            assert.equal(answer.result, 'Angela Merkel');
+            assert.equal(answer.result.label, 'Angela Merkel');
             done();
         });
     });
@@ -112,7 +112,7 @@ describe('basicQuestions', function() {
         app.answer('Who is the head of state of Germany? ', function(answer) {
             console.log(answer);
             assert.equal(answer.interpretation, 'head of state of Germany?');
-            assert.equal(answer.result, 'Joachim Gauck');
+            assert.equal(answer.result.label, 'Joachim Gauck');
             done();
         });
     });
@@ -121,7 +121,7 @@ describe('basicQuestions', function() {
 
         app.answer('Who is Germany\'s head of government? ', function(answer) {
             assert.equal(answer.interpretation, 'head of government of Germany?');
-            assert.equal(answer.result, 'Angela Merkel');
+            assert.equal(answer.result.label, 'Angela Merkel');
             done();
         });
     });
@@ -132,7 +132,7 @@ describe('basicQuestions', function() {
         app.answer('What is the cast of Inception? ', function(answer) {
             console.log(answer);
             assert.equal(answer.interpretation, 'cast member of Inception?');
-            assert.equal(answer.result, 'Leonardo DiCaprio, Ken Watanabe, Joseph Gordon-Levitt, Marion Cotillard, Ellen Page etc.');
+            assert.equal(answer.result.label, 'Leonardo DiCaprio, Ken Watanabe, Joseph Gordon-Levitt, Marion Cotillard, Ellen Page etc.');
             done();
         });
     });
@@ -143,7 +143,7 @@ describe('basicQuestions', function() {
         app.answer('Who is leading Germany? ', function(answer) {
             console.log(answer);
             assert.equal(answer.interpretation, 'head of state of Germany?');
-            assert.equal(answer.result, 'The head of state of Germany is Joachim Gauck.');
+            assert.equal(answer.result.label, 'The head of state of Germany is Joachim Gauck.');
             done();
         });
     });

--- a/test/discourseAnalysis.js
+++ b/test/discourseAnalysis.js
@@ -42,7 +42,7 @@ describe('discourseAnalysis', function() {
 
     it('remembers property from last question', function(done) {
         app.answer('Who is the president of China?', function(answ) {
-            app.answer('And from Germany?', function(answer) {
+            app.answer('And of Germany?', function(answer) {
                 assert.equal(answer.result.label, 'Joachim Gauck');
                 done();
             });

--- a/test/discourseAnalysis.js
+++ b/test/discourseAnalysis.js
@@ -40,4 +40,13 @@ describe('discourseAnalysis', function() {
         });
     });
 
+    it('remembers property from last question', function(done) {
+        app.answer('Who is the president of China?', function(answ) {
+            app.answer('And from Germany?', function(answer) {
+                assert.equal(answer.result.label, 'Joachim Gauck');
+                done();
+            });
+        });
+    });
+
 });

--- a/test/discourseAnalysis.js
+++ b/test/discourseAnalysis.js
@@ -1,0 +1,43 @@
+"use strict";
+
+var assert = require('assert');
+var app = require('./../app/wikidataQuery');
+
+describe('discourseAnalysis', function() {
+    this.timeout(15000);
+
+    it('remembers answer from last question', function(done) {
+        app.answer('Who is the president of China?', function(answ) {
+            app.answer('Where was he born?', function(answer) {
+                assert.equal(answer.result.label, 'Beijing');
+                done();
+            });
+        });
+    });
+
+    it('remembers namedEntity from last question', function(done) {
+        app.answer('Who is the president of China?', function(answ) {
+            app.answer('What is its capital?', function(answer) {
+                assert.equal(answer.result.label, 'Beijing');
+                done();
+            });
+        });
+    });
+
+    it('distinguish gender for last question', function(done) {
+        app.answer('Who is the president of Germany?', function(answ) {
+            app.answer('Where was he born?', function(answer) {
+                assert.equal(answer.result.label, 'Rostock');
+                app.answer('What is its capital?', function(answer) {
+                    assert.equal(answer.result.label, 'Berlin');
+                    app.answer('What is his capital?', function(answer) {
+                        assert.equal(answer.answer, "Sorry, I didn't find an answer on Wikidata. Maybe its data is incomplete. " +
+                                        "You would do me a big favor if you could look it up and add it to Wikidata.");
+                        done();
+                    });
+                });
+            });
+        });
+    });
+
+});


### PR DESCRIPTION
Discourse analysis was broken after merge of "spacyApproach", so I did it again. Now, we also take the gender of the entity into account and select from last 3 answerEntities and namedEntities.

It's a pretty big and complicated pull request, so some words of explanation:

To find a property, we are looking from the root of a sentence to the named entity. When there is no named entity (as it happens in discourse analysis), this would break. Therefore, I remember the position of the named entity and pass it to the property resolver as soon as we have it. If the "named entity" is "he" or "it" or something like that, I pass that position. 

Another problem with the "spacy approch" was that the propertyResolver nearly always finds something. For example for "What is the capital of China?" followed by "And of Germany" it would extract "of" as property for which the API returns results. So I defined a property as something that contains at least one noun or verb.
